### PR TITLE
Add support for Swift Package Manager

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "cd6dfb86f496fcd96ce0bc6da962cd936bf41903",
+          "version": "7.3.1"
+        }
+      },
+      {
+        "package": "Quick",
+        "repositoryURL": "https://github.com/Quick/Quick.git",
+        "state": {
+          "branch": null,
+          "revision": "5fbf13871d185526993130c3a1fad0b70bfe37ce",
+          "version": "1.3.2"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version:4.0
+import PackageDescription
+
+let package = Package(
+    name: "FlexibleDiff",
+    products: [
+        .library(name: "FlexibleDiff", targets: ["FlexibleDiff"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Quick/Quick.git", from: "1.2.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", from: "7.0.0"),
+    ],
+    targets: [
+        .target(name: "FlexibleDiff", path: "FlexibleDiff"),
+        .testTarget(name: "FlexibleDiffTests", dependencies: ["FlexibleDiff", "Quick", "Nimble"], path: "FlexibleDiffTests"),
+    ],
+    swiftLanguageVersions: [4]
+)


### PR DESCRIPTION
This does not include testing in CI as I believe that needs a bit of refactoring to include both Mac and Linux builds.