### PR TITLE
Use `Set` instead of `IndexSet` in `DiffEntry`.

### DIFF
--- a/FlexibleDiff/Changeset.swift
+++ b/FlexibleDiff/Changeset.swift
@@ -456,7 +456,7 @@ extension Changeset {
 
 private final class DiffEntry {
 	var occurenceInNew: UInt = 0
-	var locationsInOld = IndexSet()
+	var locationsInOld = Set<Int>()
 }
 
 private enum DiffReference {
@@ -490,10 +490,10 @@ private struct MovePath: Hashable {
 	}
 #endif
 
-extension IndexSet {
+extension Set where Element == Int {
 	fileprivate func closest(to integer: Int) -> Int? {
 		guard !isEmpty else { return nil }
-		return integerLessThanOrEqualTo(integer) ?? integerGreaterThan(integer)
+		return self.min { abs($0 - integer) < abs($1 - integer) }
 	}
 }
 


### PR DESCRIPTION
Profiling result shows that ~33% of time was spending in solely destroying the diff table, and a majority of them involves calls into the Objective-C runtime.

A quick performance win can be achieved by using `Set` instead of `IndexSet` in `DiffEntry`, which reduces the time spent on destruction to 15%. Note that this is done at the increased cost of handling repeated elements, which is however expected to be rare in practice at scale.