### PR TITLE
Distinguish section mutations from item mutations

### DIFF
--- a/FlexibleDiff/SectionedChangeset.swift
+++ b/FlexibleDiff/SectionedChangeset.swift
@@ -29,8 +29,8 @@ public struct SectionedChangeset {
 	/// The changes of sections.
 	///
 	/// - precondition: Offsets in `sections.mutations` and `sections.moves` must have a
-	///                 corresponding entry in `mutatedSections` if they represent a
-	///                 mutation.
+	///                 corresponding entry in `mutatedSections` if their metadata has
+	///                 been mutated.
 	public var sections = Changeset()
 
 	/// The changes of items in the mutated sections.

--- a/FlexibleDiff/SectionedChangeset.swift
+++ b/FlexibleDiff/SectionedChangeset.swift
@@ -126,11 +126,10 @@ public struct SectionedChangeset {
 			                          identifier: itemIdentifier,
 			                          areEqual: areItemsEqual)
 
-			let isMutated = !changeset.hasNoChanges
-				|| metadata.mutations.contains(sourceOffset)
+			let isMutatedMetadata = metadata.mutations.contains(sourceOffset)
 				|| mutatedMoveDests.contains(destinationOffset)
 
-			if isMutated {
+			if changeset.hasNoChanges == false {
 				let section = SectionedChangeset.MutatedSection(source: sourceOffset,
                                                                 destination: destinationOffset,
                                                                 changeset: changeset)
@@ -140,8 +139,8 @@ public struct SectionedChangeset {
 			if isMove {
 				moves.append(Changeset.Move(source: sourceOffset,
                                             destination: destinationOffset,
-                                            isMutated: isMutated))
-			} else if isMutated {
+                                            isMutated: isMutatedMetadata))
+			} else if isMutatedMetadata {
 				mutations.insert(sourceOffset)
 			}
 		}


### PR DESCRIPTION
Hello 👋

On the original implementation of FlexibleDiff we are considering a section mutation happens when:

1. A section's metadata has changed;
2. The items of the sections have changed/moved.

I've forked the library and have been using a slightly different approach where the `Changeset` only reveals a section mutation when the actual section's metadata has changed, disregarding any changes on the section's items for this purpose.

In my use case, this gives me a direct correlation between the changeset and the updates that I need to perform on a given collection view:

- I can update a section header only when a section's metadata has changed;
- When only items have changed I don't need to "refresh" the whole section.

What do you think about this approach?

Thanks for the great work! 😃